### PR TITLE
fix(lasttest): renamed targetRPS to RPSincrement

### DIFF
--- a/loadtest/config.json
+++ b/loadtest/config.json
@@ -1,10 +1,10 @@
 {
     "rampSpecifications": [
-        {"duration": 5, "targetRPS": 10},
-        {"duration": 5, "targetRPS": 5},
-        {"duration": 5, "targetRPS": 5}
+        {"duration": 5, "RPSincrement": 1},
+        {"duration": 5, "RPSincrement": 2},
+        {"duration": 5, "RPSincrement": 3}
     ],
-    "target": "localhost:8000",
+    "target": "192.168.178.98:31153",
     "paths": [
         "/admin",
         "/api"

--- a/loadtest/load/config.go
+++ b/loadtest/load/config.go
@@ -7,7 +7,7 @@ import (
 
 type RampSpecification struct {
 	Duration  int `json:"duration"`
-	TargetRPS int `json:"targetRPS"`
+	TargetRPS int `json:"RPSincrement"`
 }
 
 type TesterConfig struct {


### PR DESCRIPTION
So stiftet der Wert vielleicht weniger verwirrung. Weil ich hatte wirklich etwas komplett anderes erwartet bei der Benamung